### PR TITLE
Switch to tbShellLib

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,17 +1,17 @@
 
 *.twinproj
 
+#document code behind
 *.doccls
 
-~$*.xl?m
+#temp files
+~$*.xl?m 
 
+#demo files
+VBA/*.xl?m  
 testing/callme.xlsm
 
 Build/
 
-VBRUN/
-VBA/*.xl?m
-
-
-
-VBA/VBAHack Demo.xlsm
+#references
+twinproj/Packages/

--- a/twinproj/Settings
+++ b/twinproj/Settings
@@ -50,6 +50,21 @@
 			"versionMajor": "1",
 			"versionMinor": "0",
 			"versionRevision": "0"
+		},
+		{
+			"id": "{1FCDB98D-617D-4995-9736-2ED0E4746A10}",
+			"licence": "MIT",
+			"name": "[IMPORTED] twinBASIC Shell Library v2.9.81",
+			"path32": "/Packages/tbShellLib",
+			"path64": "/Packages/tbShellLib",
+			"publishedDate": "10-FEB-2023",
+			"publishedTime": "08:20:39",
+			"publisher": "fafalone",
+			"symbolId": "tbShellLib",
+			"versionBuild": "0",
+			"versionMajor": "2",
+			"versionMinor": "9",
+			"versionRevision": "81"
 		}
 	],
 	"project.versionMajor": 1,

--- a/twinproj/Sources/Demo.twin
+++ b/twinproj/Sources/Demo.twin
@@ -43,29 +43,39 @@ Public Class GenericCaster(Of TSource, TDest)
     End Property
 End Class
 
+Module DllEntryPoints
+    [ DllExport ]
+    Public Function GetStandardModuleAccessor(ByVal moduleName As Variant, ByVal proj As VBProject) As Object
+        Return API.GetStandardModuleAccessor(moduleName, proj)
+    End Function
+
+    [ DllExport ]
+    Public Function GetExtendedModuleAccessor(ByVal moduleName As Variant, ByVal proj As VBProject, ByRef outPrivateTI As IUnknown) As Object
+        Return API.GetExtendedModuleAccessor(moduleName, proj, outPrivateTI)
+    End Function
+End Module
+
 [ AppObject ]
 Public Class TypeLibEntryPoints
     Public Function GetStandardModuleAccessor(ByVal moduleName As String, ByVal proj As VBProject) As Object
-    	Return DllEntryPoints.GetStandardModuleAccessor(moduleName, proj)
+    	Return API.GetStandardModuleAccessor(moduleName, proj)
     End Function
     
     Public Function GetExtendedModuleAccessor(ByVal moduleName As String, ByVal proj As VBProject, Optional ByRef outPrivateTI As ITypeInfo) As Object
-    	Return DllEntryPoints.GetExtendedModuleAccessor(moduleName, proj, outPrivateTI)
+    	Return API.GetExtendedModuleAccessor(moduleName, proj, outPrivateTI)
     End Function
 End Class
 
-Module DllEntryPoints
-	[ DllExport ]
-    Public Function GetStandardModuleAccessor(ByVal moduleName As Variant, ByVal proj As VBProject) As Object
+Public Module API
+    Public Function GetStandardModuleAccessor(ByVal moduleName As String, ByVal proj As VBProject) As Object
         Logger.Log InfoLevel, printf("Invoking GetStandardModuleAccessor on {}.{}", proj.Name, moduleName)
         Dim outPublicTI As ITypeInfo
         Dim outExtendedTL As TypeLibInfo
         Set GetStandardModuleAccessor = StdModuleAccessor(moduleName, proj, proj.Name, outPublicTI, outExtendedTL)
         Logger.Log InfoLevel, printf("Discarding ITypeInfo @{} + ITypeLib* @{}", ObjPtr(outPublicTI), ObjPtr(outExtendedTL.ITypeLib))
     End Function
-    
-    [ DllExport ]
-    Public Function GetExtendedModuleAccessor(ByVal moduleName As Variant, ByVal proj As VBProject, ByRef outPrivateTI As ITypeInfo) As Object
+  
+    Public Function GetExtendedModuleAccessor(ByVal moduleName As String, ByVal proj As VBProject, ByRef outPrivateTI As ITypeInfo) As Object
         Logger.Log InfoLevel, printf("Invoking GetExtendedModuleAccessor on {}.{}", proj.Name, moduleName)
         
         'Get the base accessor (same as GetStandardModuleAccessor above) and keep the extended typelib
@@ -76,13 +86,14 @@ Module DllEntryPoints
         Logger.Log InfoLevel, printf("Got ITypeInfo @{} + ITypeLib* @{}", ObjPtr(outPublicTI), ObjPtr(outExtendedTL.ITypeLib))
         
         'The StdModuleAccessor function does obtain the correct Extended ITypeInfo
-        ' however it gets lost along the way (since VBA modules ITypeInfo is double implemented public & private)
+        ' however it gets lost along the way (since VBA modules' ITypeInfo is double implemented public & private)
         'Therefore to guarantee we have the full type info, we can get it from the hidden typelib
         ' and be VERY CAREFUL not to call QueryInterface(IID_ITypeInfo) on it, since this would resolve
         ' back to the public-only type-info
         Dim memberID As DISPID
         Dim pcFound As Integer = 1 'to get only the first matching type-info which cshould be correct
-        outExtendedTL.ITypeLib.FindName StrPtr(moduleName), 0, outPrivateTI, memberID, pcFound
+        outExtendedTL.ITypeLib.FindName moduleName, 0, outPrivateTI, memberID, pcFound
+        Assert pcFound = 1, printf("Unable to re-locate '{}' in the typelib", moduleName)
         Logger.Log InfoLevel, printf("{} PrivateITypeInfo @{}", pcFound, ObjPtr(outPrivateTI))
         
         'This tapes the full ITypeInfo to the StdModuleAccessor, allowing for IDispatch to handle the
@@ -92,6 +103,8 @@ Module DllEntryPoints
         Return swapClass
     End Function
 End Module
+
+
 
 [ COMCreatable (False) ]
 Class SwapClassEX
@@ -151,13 +164,13 @@ Class SwapClassEX
         Logger.Log DebugLevel, printf("Stored private ti@{}, supplied@{}", ObjPtr(ExtendedTypeInfo), ObjPtr(moduleTypeInfo))
         
         Dim pDefaultVTable As LongPtr = MemLongPtr(ObjPtr(Me))
-        'addressof classmethod fails as it is per instance temp stub fn
+        'AddressOf classmethod fails as it is per instance temp stub fn not the VTable function
         Logger.Log TraceLevel, "About to perform VT swap"
         ' CopyMemory pDefaultVTable + PTR_SIZE * 3, pDefaultVTable + PTR_SIZE * 7, 4 * PTR_SIZE
-        MemLongPtr(pDefaultVTable + PTR_SIZE * 3) = MemLongPtr(pDefaultVTable + PTR_SIZE * 7)'AddressOf IDispatch_GetTypeInfoCount  
-        MemLongPtr(pDefaultVTable + PTR_SIZE * 4) = MemLongPtr(pDefaultVTable + PTR_SIZE * 8)'AddressOf IDispatch_GetTypeInfo
-        MemLongPtr(pDefaultVTable + PTR_SIZE * 5) = MemLongPtr(pDefaultVTable + PTR_SIZE * 9)'AddressOf IDispatchVB_GetIDsOfNamesVB 'MemLongPtr(pOverloadVTable + PTR_SIZE * 7) 'getIDsOfNames
-        MemLongPtr(pDefaultVTable + PTR_SIZE * 6) = MemLongPtr(pDefaultVTable + PTR_SIZE * 10)'AddressOf IDispatchVB_InvokeVB 'MemLongPtr(pOverloadVTable + PTR_SIZE * 8) 'invoke
+        MemLongPtr(pDefaultVTable + PTR_SIZE * 3) = MemLongPtr(pDefaultVTable + PTR_SIZE * 7)   'AddressOf IDispatch_GetTypeInfoCount  
+        MemLongPtr(pDefaultVTable + PTR_SIZE * 4) = MemLongPtr(pDefaultVTable + PTR_SIZE * 8)   'AddressOf IDispatch_GetTypeInfo
+        MemLongPtr(pDefaultVTable + PTR_SIZE * 5) = MemLongPtr(pDefaultVTable + PTR_SIZE * 9)   'AddressOf IDispatch_GetIDsOfNames
+        MemLongPtr(pDefaultVTable + PTR_SIZE * 6) = MemLongPtr(pDefaultVTable + PTR_SIZE * 10)  'AddressOf IDispatch_Invoke
         Logger.Log TraceLevel, printf("VT swap complete {}<-{} ({}[{}])", pDefaultVTable + PTR_SIZE * 3, pDefaultVTable + PTR_SIZE * 7, 4 * PTR_SIZE, PTR_SIZE)
 
     End Sub

--- a/twinproj/Sources/Demo.twin
+++ b/twinproj/Sources/Demo.twin
@@ -104,10 +104,7 @@ Public Module API
     End Function
 End Module
 
-
-
-[ COMCreatable (False) ]
-Class SwapClassEX
+Private Class SwapClassEX
     Private Declare PtrSafe Function SysReAllocString Lib "oleaut32.dll" (ByVal pBSTR As LongPtr, Optional ByVal pszStrPtr As LongPtr) As Long
     Private ReadOnly BaseAccessor As vbInvoke.IDispatch 'don't use stdole since that doesn't have the methods visible
     Private ReadOnly ExtendedTypeInfo As ITypeInfo

--- a/twinproj/Sources/Demo.twin
+++ b/twinproj/Sources/Demo.twin
@@ -56,6 +56,7 @@ Module DllEntryPoints
 End Module
 
 [ AppObject ]
+[ Hidden ]
 Public Class TypeLibEntryPoints
     Public Function GetStandardModuleAccessor(ByVal moduleName As String, ByVal proj As VBProject) As Object
     	Return API.GetStandardModuleAccessor(moduleName, proj)

--- a/twinproj/Sources/Demo.twin
+++ b/twinproj/Sources/Demo.twin
@@ -90,7 +90,7 @@ Public Module API
         'Therefore to guarantee we have the full type info, we can get it from the hidden typelib
         ' and be VERY CAREFUL not to call QueryInterface(IID_ITypeInfo) on it, since this would resolve
         ' back to the public-only type-info
-        Dim memberID As DISPID
+        Dim memberID As MEMID
         Dim pcFound As Integer = 1 'to get only the first matching type-info which cshould be correct
         outExtendedTL.ITypeLib.FindName moduleName, 0, outPrivateTI, memberID, pcFound
         Assert pcFound = 1, printf("Unable to re-locate '{}' in the typelib", moduleName)

--- a/twinproj/Sources/ModuleReflection/TLI/OLE.twin
+++ b/twinproj/Sources/ModuleReflection/TLI/OLE.twin
@@ -1,5 +1,5 @@
 Module OLETypes
-    Public Enum DISPID
+    Public Enum MEMID
         [_]
     End Enum
 End Module

--- a/twinproj/Sources/ModuleReflection/TLI/OLE.twin
+++ b/twinproj/Sources/ModuleReflection/TLI/OLE.twin
@@ -1,13 +1,4 @@
 Module OLETypes
-    Public Type GUIDt
-        Data1 As Long
-        '@Ignore IntegerDataType
-        Data2 As Integer
-        '@Ignore IntegerDataType
-        Data3 As Integer
-        Data4(0 To 7) As Byte
-    End Type
-
     Public Enum DISPID
         [_]
     End Enum

--- a/twinproj/Sources/ModuleReflection/TLI/TypeInfoStuff.twin
+++ b/twinproj/Sources/ModuleReflection/TLI/TypeInfoStuff.twin
@@ -113,7 +113,7 @@ Module TypeInfoHelper
         getModName = getDocumentation(ITypeInfo, KnownMemberIDs.MEMBERID_NIL)
     End Function
     
-    Private Function getDocumentation(ByVal ITypeInfo As ITypeInfo, ByVal memid As DISPID) As String
+    Private Function getDocumentation(ByVal ITypeInfo As ITypeInfo, ByVal memid As MEMID) As String
         ITypeInfo.GetDocumentation memid, getDocumentation, vbNullString, 0&, vbNullString
     End Function
 

--- a/twinproj/Sources/ModuleReflection/TLI/TypeInfoStuff.twin
+++ b/twinproj/Sources/ModuleReflection/TLI/TypeInfoStuff.twin
@@ -1,131 +1,3 @@
-Module TypeInfoTypes
-    Public Enum CALLINGCONVENTION_ENUM
-        ' http://msdn.microsoft.com/en-us/library/system.runtime.interopservices.comtypes.callconv%28v=vs.110%29.aspx
-        CC_FASTCALL = 0&
-        CC_CDECL
-        CC_PASCAL
-        CC_MACPASCAL
-        CC_STDCALL                                   ' typical windows APIs
-        CC_FPFASTCALL
-        CC_SYSCALL
-        CC_MPWCDECL
-        CC_MPWPASCAL
-    End Enum
-
-	Public Type TTYPEDESC
-        pTypeDesc As LongPtr
-        vt As Integer
-    End Type
-
-    Public Type TPARAMDESC
-        pPARAMDESCEX As LongPtr
-        wParamFlags As Integer
-    End Type
-
-    Public Type TELEMDESC
-        tdesc  As TTYPEDESC
-        pdesc  As TPARAMDESC
-    End Type
-
-    Public Type TYPEATTR
-        aGUID As GUIDt
-        LCID As Long
-        dwReserved As Long
-        memidConstructor As Long
-        memidDestructor As Long
-        lpstrSchema As LongPtr
-        cbSizeInstance As Integer
-        typekind As Long
-        cFuncs As Integer
-        cVars As Integer
-        cImplTypes As Integer
-        cbSizeVft As Integer
-        cbAlignment As Integer
-        wTypeFlags As Integer
-        wMajorVerNum As Integer
-        wMinorVerNum As Integer
-        tdescAlias As Long
-        idldescType As Long
-    End Type
-
-    Public Type FUNCDESC
-        memid As DISPID                              'The function member ID (DispId).
-        lprgscode As LongPtr                         'Pointer to status code
-        lprgelemdescParam As LongPtr                 'Pointer to description of the element.
-        funckind As Long                             'virtual, static, or dispatch-only
-        
-        'VbCallType is same as tagInvokeKind
-        '#define DISPATCH_METHOD         0x1 vbMethod
-        '#define DISPATCH_PROPERTYGET    0x2 vbGet
-        '#define DISPATCH_PROPERTYPUT    0x4 vbLet
-        '#define DISPATCH_PROPERTYPUTREF 0x8 vbSet
-        INVOKEKIND As VbCallType
-        CallConv As CALLINGCONVENTION_ENUM           'typically will be stdecl
-        cParams As Integer                           'number of parameters
-        cParamsOpt As Integer                        'number of optional parameters
-        oVft As Integer                              'For FUNC_VIRTUAL, specifies the offset in the VTBL.
-        cScodes As Integer                           'The number of possible return values.
-        elemdescFunc As TELEMDESC                    'The function return type
-        wFuncFlags As Integer                        'The function flags. See FUNCFLAGS.
-    End Type
-End Module
-
-'[ITypeInfo](https://github.com/tpn/winsdk-10/blob/master/Include/10.0.16299.0/um/OAIdl.h#L2683) extends IUnknown
-'0      HRESULT  QueryInterface ([in] REFIID riid, [out] void **ppvObject)
-'1      ULONG    AddRef ()
-'2      ULONG    Release ()
-'3      HRESULT  GetTypeAttr([out] TYPEATTR **ppTypeAttr )
-'4      HRESULT  GetTypeComp([out] ITypeComp **ppTComp )
-'5      HRESULT  GetFuncDesc([in] UINT index, [out] FUNCDESC **ppFuncDesc)
-'6      HRESULT  GetVarDesc([in] UINT index, [out] VARDESC **ppVarDesc)
-'7      HRESULT  GetNames([in] MEMBERID memid, [out] BSTR *rgBstrNames, [in] UINT cMaxNames, [out] UINT *pcNames)
-'8      HRESULT  GetRefTypeOfImplType( [in] UINT index, [out] HREFTYPE *pRefType)
-'9      HRESULT  GetImplTypeFlags( [in] UINT index, [out] INT *pImplTypeFlags)
-'10     HRESULT  GetIDsOfNames( [in] LPOLESTR *rgszNames, [in] UINT cNames, [out] MEMBERID *pMemId)
-'11     HRESULT  Invoke( [in] PVOID pvInstance, [in] MEMBERID memid, [in] WORD wFlags, [out][in] DISPPARAMS *pDispParams, [out] VARIANT *pVarResult, [out] EXCEPINFO *pExcepInfo, [out] UINT *puArgErr)
-'12     HRESULT  GetDocumentation( [in] MEMBERID memid, [out] BSTR *pBstrName, [out] BSTR *pBstrDocString, [out] DWORD *pdwHelpContext, [out] BSTR *pBstrHelpFile)
-'13     HRESULT  GetDllEntry( [in] MEMBERID memid, [in] INVOKEKIND invKind, [out] BSTR *pBstrDllName, [out] BSTR *pBstrName, [out] WORD *pwOrdinal)
-'14     HRESULT  GetRefTypeInfo( [in] HREFTYPE hRefType, [out] ITypeInfo **ppTInfo)
-'15     HRESULT  AddressOfMember( [in] MEMBERID memid, [in] INVOKEKIND invKind, [out] PVOID *ppv)
-'16     HRESULT  CreateInstance( [in] IUnknown *pUnkOuter, [in] REFIID riid, [out] PVOID *ppvObj)
-'17     HRESULT  GetMops( [in] MEMBERID memid, [out] BSTR *pBstrMops)
-'18     HRESULT  GetContainingTypeLib( [out] ITypeLib **ppTLib, [out] UINT *pIndex)
-'19     void     ReleaseTypeAttr( [in] TYPEATTR *pTypeAttr)
-'20     void     ReleaseFuncDesc( [in] FUNCDESC *pFuncDesc)
-'21     void     ReleaseVarDesc( [in] VARDESC *pVarDesc)
-[ InterfaceId ("00020401-0000-0000-C000-000000000046") ]
-Interface ITypeInfo Extends IUnknown
-    
-    'HRESULT  GetTypeAttr([out] TYPEATTR **ppTypeAttr )
-    Sub GetTypeAttr(ByRef outpTypeAttr As LongPtr)
-    Sub DummyGetTypeComp()
-    'HRESULT  GetFuncDesc([in] UINT index, [out] FUNCDESC **ppFuncDesc)
-    Sub GetFuncDesc(ByVal index As Long, ByRef outpFuncDesc As LongPtr)
-    Sub DummyGetVarDesc()
-    Sub DummyGetNames()
-    Sub DummyGetRefTypeOfImplType()
-    Sub DummyGetImplTypeFlags()
-    Sub DummyGetIDsOfNames()
-    Sub DummyInvoke()
-    'HRESULT  GetDocumentation( [in] MEMBERID memid, [out] BSTR *pBstrName, [out] BSTR *pBstrDocString, [out] DWORD *pdwHelpContext, [out] BSTR *pBstrHelpFile)
-    Sub GetDocumentation(ByVal memid As DISPID, ByRef outName As String, Optional ByVal pBstrDocString As LongPtr = NULL_PTR, Optional ByVal pdwHelpContext As LongPtr = NULL_PTR, Optional ByVal pBstrHelpFile As LongPtr = NULL_PTR)
-    Sub DummyGetDllEntry()
-    Sub DummyGetRefTypeInfo()
-    Sub DummyAddressOfMember()
-    Sub DummyCreateInstance()
-    Sub DummyGetMops()
-    Sub DummyGetContainingTypeLib()
-    'void ITypeInfo::ReleaseTypeAttr( [in] TYPEATTR *pTypeAttr)
-    [ PreserveSig ]
-    Sub ReleaseTypeAttr(ByVal pTypeAttr As LongPtr)
-    [ PreserveSig ]
-    'void     ReleaseFuncDesc( [in] FUNCDESC *pFuncDesc)
-    Sub ReleaseFuncDesc(ByVal pFuncDesc As LongPtr)
-    Sub DummyReleaseVarDesc()
-End Interface
-
-
-
 [ Description ("Caching list of ITypeInfos in a given TypeLib") ]
 Private Class TypeInfoCollection
     Public ReadOnly typeLib As ITypeLib
@@ -212,10 +84,10 @@ Module TypeInfoHelper
             funcName = getFuncNameFromDescriptor(ITypeInfo, funcDescriptior)
             With funcDescriptior
                 Logger.Log InfoLevel, funcName & vbTab & Switch( _
-                    .INVOKEKIND = vbMethod, "VbMethod", _
-                    .INVOKEKIND = vbGet, "VbGet", _
-                    .INVOKEKIND = vbLet, "VbLet", _
-                    .INVOKEKIND = vbSet, "VbSet" _
+                    .invkind = vbMethod, "VbMethod", _
+                    .invkind = vbGet, "VbGet", _
+                    .invkind = vbLet, "VbLet", _
+                    .invkind = vbSet, "VbSet" _
                     ) & "@" & .memid
                 
                 'property get/set all have the same dispid so only need to be here once
@@ -224,7 +96,7 @@ Module TypeInfoHelper
                 ElseIf result(funcName) <> .memid Then
                     Err.Raise 5, Description:=funcName & "is already associated with another dispid"
                 Else
-                Assert .INVOKEKIND <> vbMethod, "this method & dispid should not appear twice"
+                Assert .invkind <> vbMethod, "this method & dispid should not appear twice"
                 End If
                 
             End With
@@ -242,12 +114,11 @@ Module TypeInfoHelper
     End Function
     
     Private Function getDocumentation(ByVal ITypeInfo As ITypeInfo, ByVal memid As DISPID) As String
-        ITypeInfo.GetDocumentation memid, getDocumentation
+        ITypeInfo.GetDocumentation memid, getDocumentation, vbNullString, 0&, vbNullString
     End Function
 
     Public Function getAttrs(ByVal ITypeInfo As ITypeInfo) As TYPEATTR
-        Dim pTypeAttr As LongPtr
-        ITypeInfo.GetTypeAttr pTypeAttr
+        Dim pTypeAttr As LongPtr = ITypeInfo.GetTypeAttr
 
         'make a local copy of the data so we can safely release the reference to the type attrs object
         'REVIEW Is it safe? Does this make the info in the attrs structure invalid?
@@ -258,8 +129,7 @@ Module TypeInfoHelper
     End Function
 
     Public Function getFuncDesc(ByVal ITypeInfo As ITypeInfo, ByVal index As Long) As FUNCDESC
-        Dim pFuncDesc As LongPtr
-        ITypeInfo.GetFuncDesc index, pFuncDesc
+        Dim pFuncDesc As LongPtr = ITypeInfo.GetFuncDesc(index)
         
         'logic same as in tryGetAttrs
         CopyMemory getFuncDesc, ByVal pFuncDesc, LenB(getFuncDesc)

--- a/twinproj/Sources/ModuleReflection/TLI/TypeLibStuff.twin
+++ b/twinproj/Sources/ModuleReflection/TLI/TypeLibStuff.twin
@@ -1,91 +1,6 @@
-'TODO tidy this up
-'    MIDL_INTERFACE ("00020402-0000-0000-C000-000000000046")
-'ITypeLib:      Public IUnknown
-'0      HRESULT  QueryInterface ([in] REFIID riid, [out] void **ppvObject)
-'1      ULONG    AddRef ()
-'2      ULONG    Release ()
-'3      UINT     GetTypeInfoCount( void) = 0;
-'4      HRESULT  GetTypeInfo(
-'            /* [in] */ UINT index,
-'            /* [out] */ __RPC__deref_out_opt ITypeInfo **ppTInfo) = 0;
-'
-'        virtual HRESULT STDMETHODCALLTYPE GetTypeInfoType(
-'            /* [in] */ UINT index,
-'            /* [out] */ __RPC__out TYPEKIND *pTKind) = 0;
-'
-'        virtual HRESULT STDMETHODCALLTYPE GetTypeInfoOfGuid(
-'            /* [in] */ __RPC__in REFGUID guid,
-'            /* [out] */ __RPC__deref_out_opt ITypeInfo **ppTinfo) = 0;
-'
-'        virtual /* [local] */ HRESULT STDMETHODCALLTYPE GetLibAttr(
-'            /* [out] */ TLIBATTR **ppTLibAttr) = 0;
-'
-'        virtual HRESULT STDMETHODCALLTYPE GetTypeComp(
-'            /* [out] */ __RPC__deref_out_opt ITypeComp **ppTComp) = 0;
-'
-'        virtual /* [local] */ HRESULT STDMETHODCALLTYPE GetDocumentation(
-'            /* [in] */ INT index,
-'            /* [annotation][out] */
-'            _Outptr_opt_  BSTR *pBstrName,
-'            /* [annotation][out] */
-'            _Outptr_opt_  BSTR *pBstrDocString,
-'            /* [out] */ DWORD *pdwHelpContext,
-'            /* [annotation][out] */
-'            _Outptr_opt_  BSTR *pBstrHelpFile) = 0;
-'
-'        virtual /* [local] */ HRESULT STDMETHODCALLTYPE IsName(
-'            /* [annotation][out][in] */
-'            __RPC__inout  LPOLESTR szNameBuf,
-'            /* [in] */ ULONG lHashVal,
-'            /* [out] */ BOOL *pfName) = 0;
-'
-'        virtual /* [local] */ HRESULT STDMETHODCALLTYPE FindName(
-'            /* [annotation][out][in] */
-'            __RPC__inout  LPOLESTR szNameBuf,
-'            /* [in] */ ULONG lHashVal,
-'            /* [length_is][size_is][out] */ ITypeInfo **ppTInfo,
-'            /* [length_is][size_is][out] */ MEMBERID *rgMemId,
-'            /* [out][in] */ USHORT *pcFound) = 0;
-'
-'        virtual /* [local] */ void STDMETHODCALLTYPE ReleaseTLibAttr(
-'            /* [in] */ TLIBATTR *pTLibAttr) = 0;
-'
-'    };
-[ InterfaceId ("00020402-0000-0000-C000-000000000046") ]
-Interface ITypeLib Extends IUnknown
-    [ PreserveSig ]
-    Function GetTypeInfoCount() As Long
-    Sub GetTypeInfo(ByVal index As Long, ByRef outTI As ITypeInfo)
-    Sub DummyGetTypeInfoType()
-    Sub DummyGetTypeInfoOfGuid()
-    Sub DummyGetLibAttr()
-    Sub GetTypeComp()
-    
-'        virtual /* [local] */ HRESULT STDMETHODCALLTYPE GetDocumentation(
-'            /* [in] */ INT index,
-'            /* [annotation][out] */
-'            _Outptr_opt_  BSTR *pBstrName,
-'            /* [annotation][out] */
-'            _Outptr_opt_  BSTR *pBstrDocString,
-'            /* [out] */ DWORD *pdwHelpContext,
-'            /* [annotation][out] */
-'            _Outptr_opt_  BSTR *pBstrHelpFile) = 0;
-    Sub GetDocumentation(ByVal memid As DISPID, ByRef outName As String, Optional ByVal pBstrDocString As LongPtr = NULL_PTR, Optional ByVal pdwHelpContext As LongPtr = NULL_PTR, Optional ByVal pBstrHelpFile As LongPtr = NULL_PTR)
-    Sub DummyIsName()
-    'HRESULT FindName(
-    '  [in, out] LPOLESTR  szNameBuf,
-    '  [in]      ULONG     lHashVal,
-    '  [out]     ITypeInfo **ppTInfo,
-    '  [out]     MEMBERID  *rgMemId,
-    '  [in, out] USHORT * pcFound
-    ');
-    Sub FindName(ByVal szNameBuf As LongPtr, ByVal lHashVal As Long, ByRef outTypeInfoArrayFirst As ITypeInfo, ByRef outMemIDArrayFirst As Long, ByRef pcFound As Integer)
-    Sub DummyReleaseTLibAttr()
-End Interface
-
 Module TypeLibHelper
     Public Function getITypeInfoByIndex(ByVal ITypeLib As ITypeLib, ByVal index As Long) As ITypeInfo
-        ITypeLib.GetTypeInfo(index, getITypeInfoByIndex)
+        Return ITypeLib.GetTypeInfo(index)
     End Function
 
     Public Function getProjName(ByVal ITypeLib As ITypeLib) As String
@@ -94,7 +9,7 @@ Module TypeLibHelper
     End Function
     
     Private Function getDocumentation(ByVal ITypeLib As ITypeLib, ByVal memid As DISPID) As String
-        ITypeLib.GetDocumentation memid, getDocumentation
+        ITypeLib.GetDocumentation memid, getDocumentation, vbNullString, 0&, vbNullString
     End Function
 End Module
 

--- a/twinproj/Sources/ModuleReflection/TLI/TypeLibStuff.twin
+++ b/twinproj/Sources/ModuleReflection/TLI/TypeLibStuff.twin
@@ -8,7 +8,7 @@ Module TypeLibHelper
         getProjName = getDocumentation(ITypeLib, KnownMemberIDs.MEMBERID_NIL)
     End Function
     
-    Private Function getDocumentation(ByVal ITypeLib As ITypeLib, ByVal memid As DISPID) As String
+    Private Function getDocumentation(ByVal ITypeLib As ITypeLib, ByVal memid As MEMID) As String
         ITypeLib.GetDocumentation memid, getDocumentation, vbNullString, 0&, vbNullString
     End Function
 End Module

--- a/twinproj/Sources/ModuleReflection/TLI/TypeLibStuff.twin
+++ b/twinproj/Sources/ModuleReflection/TLI/TypeLibStuff.twin
@@ -13,8 +13,7 @@ Module TypeLibHelper
     End Function
 End Module
 
-[ COMCreatable (False) ]
-Class TypeLibInfo
+Private Class TypeLibInfo
     Private Type TTypeLibInfo
         ITypeLib As ITypeLib
         typeInfos As TypeInfoCollection

--- a/twinproj/Sources/ModuleReflection/VBEStuff.twin
+++ b/twinproj/Sources/ModuleReflection/VBEStuff.twin
@@ -9,7 +9,7 @@
 'End Enum
 
 [ InterfaceId ("DDD557E1-D96F-11CD-9570-00AA0051E5D4") ]
-Interface IVBEComponent Extends IUnknown
+Private Interface IVBEComponent Extends IUnknown
 	Sub Placeholder01()
     Sub Placeholder02()
     Sub Placeholder03()


### PR DESCRIPTION
This switch enables more complete interfaces for ITypeInfo. It comes at the expense of twinpack size x6 

However dll build size is unaffected because of tB's dead code removal